### PR TITLE
Fix version dropdown sorting to use numerical comparison

### DIFF
--- a/index.html
+++ b/index.html
@@ -450,7 +450,7 @@
                 });
             });
 
-            const versions = [...versionSet].sort();
+            const versions = [...versionSet].sort(compareVersions);
             const versionFrom = document.getElementById('version-from');
             const versionTo = document.getElementById('version-to');
 
@@ -471,10 +471,12 @@
             defectsData.forEach(defect => {
                 Object.keys(defect.version_history).forEach(v => defectVersions.add(v));
             });
-            const sortedDefectVersions = [...defectVersions].sort();
+            const sortedDefectVersions = [...defectVersions].sort(compareVersions);
+            console.log(`Populating defect version filter with ${sortedDefectVersions.length} versions`);
             sortedDefectVersions.forEach(version => {
                 defectVersionFilter.add(new Option(version, version));
             });
+            console.log(`Defect version filter now has ${defectVersionFilter.options.length} options`);
         }
 
         // Setup event listeners


### PR DESCRIPTION
## Issue

Version dropdowns were using alphabetical sorting instead of numerical sorting, causing incorrect ordering:
- Incorrect: 10.0.00, 8.0.90, 8.0.91, 9.0.00
- Correct: 8.0.90, 8.0.91, 9.0.00, 10.0.00

## Changes

- Use `compareVersions()` function for sorting all version dropdowns
  - Feature compare dropdowns (Version 1 and Version 2)
  - Defect tracker dropdown (Show defects in)
- Add console logging to help debug version filter population
- Ensures all 94 versions in defects data are properly sorted

## Testing

- [x] Verified compareVersions function handles all version formats correctly
- [x] Tested with version strings: 8.0.90, 8.0.91, 9.0.00, 10.0.00, 10.0.10a_cd3
- [x] Confirmed console logging shows correct version count

## Before/After

**Before:** Alphabetical sort placed "10.x" versions before "8.x" and "9.x"  
**After:** Numerical sort places versions in chronological release order